### PR TITLE
Add complete support for CBOR_SIZEOF_* macros.

### DIFF
--- a/inc/dps/private/cbor.h
+++ b/inc/dps/private/cbor.h
@@ -85,7 +85,7 @@ extern "C" {
 /**
  * Actual bytes needed to encode a byte stream of a specified length
  */
-#define CBOR_SIZEOF_BSTR(l)     ((l) + CBOR_SIZEOF_LEN(l))
+#define CBOR_SIZEOF_BYTES(l)     ((l) + CBOR_SIZEOF_LEN(l))
 
 /**
  * Maximum bytes needed to encode an integer type
@@ -95,7 +95,46 @@ extern "C" {
 /**
  * Actual bytes need to encode a boolean
  */
-#define CBOR_SIZEOF_BOOL        (1)
+#define CBOR_SIZEOF_BOOLEAN()    (1)
+
+/**
+ * Actual bytes need to encode an unsigned integer
+ */
+#define CBOR_SIZEOF_UINT(n)      CBOR_SIZEOF_LEN(n)
+
+/**
+ * Actual bytes need to encode a signed integer
+ */
+#define CBOR_SIZEOF_INT(i)       _CBOR_SizeOfInt(i)
+
+/**
+ * Actual bytes need to encode a tag
+ */
+#define CBOR_SIZEOF_TAG(n)       CBOR_SIZEOF_LEN(n)
+
+/**
+ * Actual bytes need to encode a null
+ */
+#define CBOR_SIZEOF_NULL()       (1)
+
+/**
+ * Actual bytes need to encode a float
+ */
+#define CBOR_SIZEOF_FLOAT()      (5)
+
+/**
+ * Actual bytes need to encode a double
+ */
+#define CBOR_SIZEOF_DOUBLE()     (9)
+
+/**
+ * Actual bytes need to encode a signed integer
+ *
+ * @param i The signed integer
+ *
+ * @return The number of bytes needed
+ */
+size_t _CBOR_SizeOfInt(int64_t i);
 
 /**
  * Actual bytes need to encode a string (includes NUL terminator)

--- a/src/ack.c
+++ b/src/ack.c
@@ -123,7 +123,7 @@ static DPS_Status SerializeAck(const DPS_Publication* pub, PublicationAck* ack, 
           CBOR_SIZEOF(uint8_t) +
           CBOR_SIZEOF(uint8_t) +
           CBOR_SIZEOF_MAP(2) + 2 * CBOR_SIZEOF(uint8_t) +
-          CBOR_SIZEOF_BSTR(sizeof(DPS_UUID)) +
+          CBOR_SIZEOF_BYTES(sizeof(DPS_UUID)) +
           CBOR_SIZEOF(uint32_t);
     ret = DPS_TxBufferInit(&ack->buf, NULL, len);
     if (ret != DPS_OK) {
@@ -166,7 +166,7 @@ static DPS_Status SerializeAck(const DPS_Publication* pub, PublicationAck* ack, 
      */
     if (ret == DPS_OK) {
         len = CBOR_SIZEOF_MAP(1) + CBOR_SIZEOF(uint8_t) +
-            CBOR_SIZEOF_BSTR(dataLen);
+            CBOR_SIZEOF_BYTES(dataLen);
         ret = DPS_TxBufferInit(&ack->encryptedBuf, NULL, len);
     }
     if (ret == DPS_OK) {

--- a/src/bitvec.c
+++ b/src/bitvec.c
@@ -751,7 +751,7 @@ DPS_Status DPS_BitVectorSerialize(DPS_BitVector* bv, DPS_TxBuffer* buffer)
 
 size_t DPS_BitVectorSerializeMaxSize(DPS_BitVector* bv)
 {
-    return CBOR_SIZEOF_ARRAY(3) + CBOR_SIZEOF(uint8_t) + CBOR_SIZEOF(uint32_t) + CBOR_SIZEOF_BSTR(bv->len / 8);
+    return CBOR_SIZEOF_ARRAY(3) + CBOR_SIZEOF(uint8_t) + CBOR_SIZEOF(uint32_t) + CBOR_SIZEOF_BYTES(bv->len / 8);
 }
 
 DPS_Status DPS_BitVectorDeserialize(DPS_BitVector* bv, DPS_RxBuffer* buffer)

--- a/src/cbor.c
+++ b/src/cbor.c
@@ -207,6 +207,15 @@ DPS_Status CBOR_EncodeUint(DPS_TxBuffer* buffer, uint64_t n)
     return EncodeUint(buffer, n, CBOR_UINT);
 }
 
+size_t _CBOR_SizeOfInt(int64_t i)
+{
+    if (i >= 0) {
+        return CBOR_SIZEOF_LEN((uint64_t)i);
+    } else {
+        return CBOR_SIZEOF_LEN(~(uint64_t)i);
+    }
+}
+
 DPS_Status CBOR_EncodeInt(DPS_TxBuffer* buffer, int64_t i)
 {
     if (i >= 0) {

--- a/src/cose.c
+++ b/src/cose.c
@@ -46,29 +46,29 @@ DPS_DEBUG_CONTROL(DPS_DEBUG_ON);
 
 #define A256KW_LEN 40
 
-#define SIZEOF_PROTECTED_MAP CBOR_SIZEOF_BSTR(CBOR_SIZEOF_MAP(1) +      \
+#define SIZEOF_PROTECTED_MAP CBOR_SIZEOF_BYTES(CBOR_SIZEOF_MAP(1) +      \
     /* alg */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF(int8_t))
 
 #define SIZEOF_SIGNATURE 132 /* See comments in Verify_ECDSA() for explanation */
 
 #define SIZEOF_COUNTER_SIGNATURE(kidLen) CBOR_SIZEOF_ARRAY(3) +         \
     SIZEOF_PROTECTED_MAP +                                              \
-    CBOR_SIZEOF_MAP(1) + /* kid */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BSTR(kidLen) + \
-    CBOR_SIZEOF_BSTR(SIZEOF_SIGNATURE)
+    CBOR_SIZEOF_MAP(1) + /* kid */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BYTES(kidLen) + \
+    CBOR_SIZEOF_BYTES(SIZEOF_SIGNATURE)
 
 #define SIZEOF_EPHEMERAL_KEY CBOR_SIZEOF_MAP(4) +                       \
     /* kty */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF(int8_t) +               \
     /* crv */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF(int8_t) +               \
-    /* x */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BSTR(EC_MAX_COORD_LEN) +  \
-    /* y */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BSTR(EC_MAX_COORD_LEN)
+    /* x */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BYTES(EC_MAX_COORD_LEN) + \
+    /* y */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BYTES(EC_MAX_COORD_LEN)
 
 #define SIZEOF_RECIPIENT(kidLen) CBOR_SIZEOF_ARRAY(3) +                 \
     SIZEOF_PROTECTED_MAP +                                              \
     CBOR_SIZEOF_MAP(2) +                                                \
     /* alg */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF(int8_t) +               \
     /* ephemeral key */ CBOR_SIZEOF(int8_t) + SIZEOF_EPHEMERAL_KEY +    \
-    /* kid */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BSTR(kidLen) +          \
-    /* content */ CBOR_SIZEOF_BSTR(A256KW_LEN)
+    /* kid */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BYTES(kidLen) +         \
+    /* content */ CBOR_SIZEOF_BYTES(A256KW_LEN)
 
 #define SIZEOF_PARTY_INFO CBOR_SIZEOF_ARRAY(3) +        \
     /* null */ 1 +                                      \
@@ -355,11 +355,11 @@ static DPS_Status EncodeSig(DPS_TxBuffer* buf, int8_t alg, int8_t sigAlg,
     size_t bufLen;
 
     bufLen = CBOR_SIZEOF_ARRAY(5) +
-        CBOR_SIZEOF_BSTR(sizeof(COUNTER_SIGNATURE)) +
+        CBOR_SIZEOF_BYTES(sizeof(COUNTER_SIGNATURE)) +
         SIZEOF_PROTECTED_MAP +
         SIZEOF_PROTECTED_MAP +
-        CBOR_SIZEOF_BSTR(aadLen) +
-        CBOR_SIZEOF_BSTR(payloadLen);
+        CBOR_SIZEOF_BYTES(aadLen) +
+        CBOR_SIZEOF_BYTES(payloadLen);
 
     ret = DPS_TxBufferInit(buf, NULL, bufLen);
     if (ret == DPS_OK) {
@@ -418,9 +418,9 @@ static DPS_Status EncodeAAD(DPS_TxBuffer* buf, uint8_t tag, int8_t alg, uint8_t*
         return DPS_ERR_INVALID;
     }
     bufLen = CBOR_SIZEOF_ARRAY(3) +
-        CBOR_SIZEOF_BSTR(contextLen) +
+        CBOR_SIZEOF_BYTES(contextLen) +
         SIZEOF_PROTECTED_MAP +
-        CBOR_SIZEOF_BSTR(aadLen);
+        CBOR_SIZEOF_BYTES(aadLen);
 
     ret = DPS_TxBufferInit(buf, NULL, bufLen);
     if (ret == DPS_OK) {
@@ -830,8 +830,8 @@ DPS_Status COSE_Encrypt(int8_t alg, const uint8_t nonce[COSE_NONCE_LEN], const C
         CBOR_SIZEOF_ARRAY(4) +
         SIZEOF_PROTECTED_MAP +
         CBOR_SIZEOF_MAP(2) +
-        /* iv */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BSTR(COSE_NONCE_LEN) +
-        CBOR_SIZEOF_BSTR(DPS_TxBufferUsed(&content));
+        /* iv */ CBOR_SIZEOF(int8_t) + CBOR_SIZEOF_BYTES(COSE_NONCE_LEN) +
+        CBOR_SIZEOF_BYTES(DPS_TxBufferUsed(&content));
     if (signer) {
         ctLen += /* counter signature */ CBOR_SIZEOF(int8_t) + SIZEOF_COUNTER_SIGNATURE(sig.kid.len);
     }

--- a/src/pub.c
+++ b/src/pub.c
@@ -1358,10 +1358,10 @@ DPS_Status DPS_SerializePub(DPS_Node* node, DPS_Publication* pub, const uint8_t*
      * Encode the protected map
      */
     len = CBOR_SIZEOF_MAP(5) + 5 * CBOR_SIZEOF(uint8_t) +
-        CBOR_SIZEOF_BSTR(sizeof(DPS_UUID)) +
+        CBOR_SIZEOF_BYTES(sizeof(DPS_UUID)) +
         CBOR_SIZEOF(uint32_t) +
-        CBOR_SIZEOF_BOOL +
-        CBOR_SIZEOF_BSTR(bfLen) +
+        CBOR_SIZEOF_BOOLEAN() +
+        CBOR_SIZEOF_BYTES(bfLen) +
         CBOR_SIZEOF(int16_t);
     ret = DPS_TxBufferInit(&protectedBuf, NULL, len);
     if (ret != DPS_OK) {
@@ -1405,7 +1405,7 @@ DPS_Status DPS_SerializePub(DPS_Node* node, DPS_Publication* pub, const uint8_t*
     if (ret == DPS_OK) {
         len = CBOR_SIZEOF_MAP(2) + 2 * CBOR_SIZEOF(uint8_t) +
             topicsLen +
-            CBOR_SIZEOF_BSTR(dataLen);
+            CBOR_SIZEOF_BYTES(dataLen);
         ret = DPS_TxBufferInit(&encryptedBuf, NULL, len);
     }
     if (ret == DPS_OK) {

--- a/src/sub.c
+++ b/src/sub.c
@@ -227,7 +227,7 @@ DPS_Status DPS_SendSubscription(DPS_Node* node, RemoteNode* remote)
         interests = remote->outbound.deltaInd ? remote->outbound.delta : remote->outbound.interests;
         len += 4 * CBOR_SIZEOF(uint8_t) +
                CBOR_SIZEOF(uint8_t) +
-               CBOR_SIZEOF_BSTR(sizeof(DPS_UUID)) +
+               CBOR_SIZEOF_BYTES(sizeof(DPS_UUID)) +
                DPS_BitVectorSerializeMaxSize(interests) +
                DPS_BitVectorSerializeMaxSize(remote->outbound.needs);
     } else {


### PR DESCRIPTION
- Use consistent naming (BSTR vs. BYTES)

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>