### PR TITLE
Allow CBOR-encode double <-> float coersion

### DIFF
--- a/inc/dps/err.h
+++ b/inc/dps/err.h
@@ -68,6 +68,7 @@ typedef int DPS_Status; /**< The status code type */
 #define DPS_ERR_SECURITY          24 /**< A security related error - failure to decrypt or authenticate */
 #define DPS_ERR_NOT_ENCRYPTED     25 /**< Payload does not appear to be encrypted */
 #define DPS_ERR_STOPPING          26 /**< The current node is stopping */
+#define DPS_ERR_RANGE             27 /**< A value is out of range */
 
 /**
  * The text string representation of the status code.

--- a/src/err.c
+++ b/src/err.c
@@ -57,6 +57,7 @@ const char* DPS_ErrTxt(DPS_Status s)
         ERR_CASE(DPS_ERR_SECURITY);
         ERR_CASE(DPS_ERR_NOT_ENCRYPTED);
         ERR_CASE(DPS_ERR_STOPPING);
+        ERR_CASE(DPS_ERR_RANGE);
     default:
         snprintf(buf, sizeof(buf), "ERR%d", s);
         return buf;


### PR DESCRIPTION
If a CBOR encoded double fits in the range of a float we permit is to be decoded into a float (with potential loss of
precision). Similarly CBOR encoded floats can now be decoded as doubles. This behavior is more consistent with the way integer
decoding is handled. A new error status DPS_ERR_RANGE flags decode errors for all numeric types where the CBOR encode
was correct but the decoded value cannot be represented within the range of the target type.