### PR TITLE
Convert CBOR int encodings to float or double

### DIFF
--- a/inc/dps/err.h
+++ b/inc/dps/err.h
@@ -69,6 +69,7 @@ typedef int DPS_Status; /**< The status code type */
 #define DPS_ERR_NOT_ENCRYPTED     25 /**< Payload does not appear to be encrypted */
 #define DPS_ERR_STOPPING          26 /**< The current node is stopping */
 #define DPS_ERR_RANGE             27 /**< A value is out of range */
+#define DPS_ERR_LOST_PRECISION    28 /**< Precision was lost when converting a value */
 
 /**
  * The text string representation of the status code.

--- a/src/err.c
+++ b/src/err.c
@@ -58,6 +58,7 @@ const char* DPS_ErrTxt(DPS_Status s)
         ERR_CASE(DPS_ERR_NOT_ENCRYPTED);
         ERR_CASE(DPS_ERR_STOPPING);
         ERR_CASE(DPS_ERR_RANGE);
+        ERR_CASE(DPS_ERR_LOST_PRECISION);
     default:
         snprintf(buf, sizeof(buf), "ERR%d", s);
         return buf;

--- a/test/cbortest.c
+++ b/test/cbortest.c
@@ -68,7 +68,17 @@ static const double Doubles[] = {
 };
 
 static const double DoublesAsFloat[] = {
-    0.0, -FLT_MAX, FLT_MAX, (double)FLT_MAX * 1.0000000000000002
+    0.0, -FLT_MAX, FLT_MAX, (double)FLT_MAX * 1.0000000000000002, 12345.67890123
+};
+
+// Surprisingly INT32_MIN can be represented exactly as a float!
+static const int64_t IntsAsFloat[] = {
+    0, 202, -202, -16777216ll, 16777216ll, -16777217ll, 16777217ll, INT32_MAX, INT32_MIN + 1
+};
+
+// Surprisingly INT64_MIN can be represented exactly as a double!
+static const int64_t IntsAsDouble[] = {
+    0, 2, -3, -9007199254740992ll, 9007199254740992ll, INT32_MAX, INT32_MIN, -9007199254740993ll, 9007199254740993ll, INT64_MAX, INT64_MIN + 1
 };
 
 static DPS_Status TestFloatingPoint()
@@ -97,7 +107,7 @@ static DPS_Status TestFloatingPoint()
     return DPS_OK;
 }
 
-#define NUM_ENCODED_VALS   63
+#define NUM_ENCODED_VALS   84
 
 int main(int argc, char** argv)
 {
@@ -149,6 +159,14 @@ int main(int argc, char** argv)
         }
         for (i = 0; i < sizeof(DoublesAsFloat) / sizeof(DoublesAsFloat[0]); ++i) {
             ret = CBOR_EncodeDouble(&txBuffer, DoublesAsFloat[i]);
+            CHECK(ret);
+        }
+        for (i = 0; i < sizeof(IntsAsDouble) / sizeof(IntsAsDouble[0]); ++i) {
+            ret = CBOR_EncodeInt(&txBuffer, IntsAsDouble[i]);
+            CHECK(ret);
+        }
+        for (i = 0; i < sizeof(IntsAsFloat) / sizeof(IntsAsFloat[0]); ++i) {
+            ret = CBOR_EncodeInt(&txBuffer, IntsAsFloat[i]);
             CHECK(ret);
         }
         ret = CBOR_EncodeArray(&txBuffer, sizeof(Strings) / sizeof(Strings[0]));
@@ -270,24 +288,77 @@ int main(int argc, char** argv)
         ASSERT((d == Doubles[i]) || (isnan(d) && isnan(Doubles[i])));
         CHECK(ret);
     }
-
     // These are doubles on the wire
     for (i = 0; i < sizeof(DoublesAsFloat) / sizeof(DoublesAsFloat[0]); ++i) {
         float f;
         ret = CBOR_DecodeFloat(&rxBuffer, &f);
-        if (i < 3) {
-            ASSERT(f == (float)DoublesAsFloat[i]);
-            CHECK(ret);
-        } else {
+        switch (i) {
+        case 3:
             if (ret == DPS_ERR_RANGE) {
-                printf("Decode %f failed as expected %d\n", DoublesAsFloat[i], ret);
+                printf("Decode %f failed as expected %s\n", DoublesAsFloat[i], DPS_ErrTxt(ret));
                 ret = DPS_OK;
             } else {
                 printf("Decode %f did not fail as expected\n", DoublesAsFloat[i]);
                 ret = DPS_ERR_INVALID;
             }
-            CHECK(ret);
+            break;
+        case 4:
+            if (ret == DPS_ERR_LOST_PRECISION) {
+                printf("Decode %f failed as expected %s\n", DoublesAsFloat[i], DPS_ErrTxt(ret));
+                ret = DPS_OK;
+            } else {
+                printf("Decode %f did not fail as expected\n", DoublesAsFloat[i]);
+                ret = DPS_ERR_INVALID;
+            }
+            break;
+        default:
+            ASSERT(f == (float)DoublesAsFloat[i]);
         }
+        CHECK(ret);
+    }
+    // These are integers on the wire - decode as doubles
+    for (i = 0; i < sizeof(IntsAsDouble) / sizeof(IntsAsDouble[0]); ++i) {
+        double d;
+        ret = CBOR_DecodeDouble(&rxBuffer, &d);
+        switch (i) {
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+            if (ret == DPS_ERR_LOST_PRECISION) {
+                printf("Decode %zi failed as expected %s\n", IntsAsDouble[i], DPS_ErrTxt(ret));
+                ret = DPS_OK;
+            } else {
+                printf("Decode %zi did not fail as expected\n", IntsAsDouble[i]);
+                ret = DPS_ERR_INVALID;
+            }
+            break;
+        default:
+            ASSERT(d == (double)IntsAsDouble[i]);
+        }
+        CHECK(ret);
+    }
+    // These are integers on the wire - decode as floats
+    for (i = 0; i < sizeof(IntsAsFloat) / sizeof(IntsAsFloat[0]); ++i) {
+        float f;
+        ret = CBOR_DecodeFloat(&rxBuffer, &f);
+        switch (i) {
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+            if (ret == DPS_ERR_LOST_PRECISION) {
+                printf("Decode %zi failed as expected %s\n", IntsAsFloat[i], DPS_ErrTxt(ret));
+                ret = DPS_OK;
+            } else {
+                printf("Decode %zi did not fail as expected\n", IntsAsFloat[i]);
+                ret = DPS_ERR_INVALID;
+            }
+            break;
+        default:
+            ASSERT(f == (float)IntsAsFloat[i]);
+        }
+        CHECK(ret);
     }
 
     ret = CBOR_DecodeArray(&rxBuffer, &size);


### PR DESCRIPTION
CBOR encodings for integers use the smallest possible encoding
depending on the value. On decode the value is automatically converted
provided the converted value is in the required range. This change allows
a similar conversion from integer encoded CBOR to float or double provided
the conversion does not reuslt in a loss of precision. If precision is lost
the value is still converted but a new error status DPS_ERR_LOST_PRECISION
is returned allowing the application to decide how the handle this case.

Signed-off-by: Greg Burns <gregory.burns@intel.com>