### PR TITLE
Fix check for ERROR messages in test runner.

### DIFF
--- a/test_scripts/common.py
+++ b/test_scripts/common.py
@@ -375,6 +375,6 @@ def expect_ack_received(children, allow_error=False):
     expect(children, 'Ack for pub')
 
 def expect_error(children, error):
-    expect(children, 'ERROR.*{}'.format(error))
+    expect(children, 'ERROR.*{}'.format(error), allow_error=True)
 
 reset_logs()

--- a/test_scripts/versioning.py
+++ b/test_scripts/versioning.py
@@ -33,7 +33,7 @@ reset_logs()
 sub1 = sub('A')
 ver('-v 2')
 
-expect(sub1, 'ERROR.*Expected message version 1, received 2')
+expect_error(sub1, 'Expected message version 1, received 2')
 
 # Unicast
 reset_logs()
@@ -41,7 +41,7 @@ reset_logs()
 sub1 = sub('A')
 ver('-p {} -v 2'.format(sub1.port))
 
-expect(sub1, 'ERROR.*Expected message version 1, received 2')
+expect_error(sub1, 'Expected message version 1, received 2')
 
 #
 # Verify that unsupported message type is dropped
@@ -52,7 +52,7 @@ reset_logs()
 sub1 = sub('A')
 ver('-v 1 -t 5')
 
-expect(sub1, 'ERROR.*Invalid message type')
+expect_error(sub1, 'Invalid message type')
 
 # Unicast
 reset_logs()
@@ -60,4 +60,4 @@ reset_logs()
 sub1 = sub('A')
 ver('-p {} -v 1 -t 5'.format(sub1.port))
 
-expect(sub1, 'ERROR.*Invalid message type')
+expect_error(sub1, 'Invalid message type')


### PR DESCRIPTION
Previously the versioning test did not set allow_error=True so the
expected output was ['ERROR.*Invalid...', 'ERROR'].  Pexpect would
then see 'ERROR' (the second item, not the first) on partial output
and fail the test.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>