### PR TITLE
Add CBOR_SIZEOF macro for CBOR_EncodeStringAndLength.

### DIFF
--- a/inc/dps/private/cbor.h
+++ b/inc/dps/private/cbor.h
@@ -97,6 +97,11 @@ extern "C" {
 #define CBOR_SIZEOF_STATIC_STRING(s)    ((sizeof(s) - 1) + CBOR_SIZEOF_LEN(sizeof(s) - 1))
 
 /**
+ * Actual bytes need to encode a string of length bytes
+ */
+#define CBOR_SIZEOF_STRING_AND_LENGTH(l)    ((l) + CBOR_SIZEOF_LEN(l))
+
+/**
  * Actual bytes needed to encode a byte stream of a specified length
  */
 #define CBOR_SIZEOF_BYTES(l)     ((l) + CBOR_SIZEOF_LEN(l))


### PR DESCRIPTION
Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>