### PR TITLE
With -j flag decode ACK as JSON

### DIFF
--- a/examples/publisher.c
+++ b/examples/publisher.c
@@ -142,7 +142,15 @@ static void OnAck(DPS_Publication* pub, uint8_t* data, size_t len)
     DPS_PRINT("Ack for pub UUID %s(%d) [%s]\n", DPS_UUIDToString(DPS_PublicationGetUUID(pub)),
               DPS_PublicationGetSequenceNum(pub), KeyIdToString(DPS_AckGetSenderKeyId(pub)));
     if (len) {
-        DPS_PRINT("    %.*s\n", (int)len, data);
+        if (json) {
+            char jsonStr[1024];
+            DPS_Status ret = DPS_CBOR2JSON(data, len, jsonStr, sizeof(jsonStr), DPS_TRUE);
+            if (ret == DPS_OK) {
+                DPS_PRINT("%s\n", jsonStr);
+            }
+        } else {
+            DPS_PRINT("%.*s\n", (int)len, data);
+        }
     }
 }
 


### PR DESCRIPTION
With the -j option on the command line the message text is treated as JSON and the publication payload is CBOR encoded on the wire. With this change, when -j is specified for a publication it is assumed that the ACK payload is also CBOR encoded so is decoded into JSON.