### PR TITLE
Remove dependency of uv.h from public header files.

### DIFF
--- a/doc/tutorial/tutorial.c
+++ b/doc/tutorial/tutorial.c
@@ -23,6 +23,11 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <netinet/in.h>
+#endif
 #include <dps/dbg.h>
 #include <dps/event.h>
 /** [Prerequisites] */

--- a/examples/keys.c
+++ b/examples/keys.c
@@ -22,6 +22,7 @@
 
 #include "keys.h"
 #include <ctype.h>
+#include <stdio.h>
 #include <string.h>
 
 static const DPS_UUID _NetworkKeyId = {

--- a/inc/dps/dps.h
+++ b/inc/dps/dps.h
@@ -30,9 +30,13 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#ifdef _WIN32
+#include <winsock2.h>
+#else
+#include <sys/socket.h>
+#endif
 #include <dps/err.h>
 #include <dps/uuid.h>
-#include <uv.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -535,17 +539,6 @@ DPS_Status DPS_DestroyNode(DPS_Node* node, DPS_OnNodeDestroyed cb, void* data);
  * @param subsRateMsecs  The time delay (in msecs) between updates
  */
 void DPS_SetNodeSubscriptionUpdateDelay(DPS_Node* node, uint32_t subsRateMsecs);
-
-/**
- * Get the uv event loop for this node. The only thing that is safe to do with the node
- * is to create an async callback. Other libuv APIs can then be called from within the
- * async callback.
- *
- * @param node     The local node to use
- *
- * @return The uv event loop
- */
-uv_loop_t* DPS_GetLoop(DPS_Node* node);
 
 /**
  * Get the port number this node is listening for connections on

--- a/inc/dps/private/dps.h
+++ b/inc/dps/private/dps.h
@@ -215,7 +215,7 @@ struct _DPS_KeyStoreRequest {
     /** Called to provide a key to the requestor */
     DPS_Status (*setKey)(DPS_KeyStoreRequest* request, const DPS_Key* key);
     /** Called to provide the CA chain to the requestor */
-    DPS_Status (*setCA)(DPS_KeyStoreRequest* request, const char* ca); 
+    DPS_Status (*setCA)(DPS_KeyStoreRequest* request, const char* ca);
     /** Called to provide a certificate to the requestor */
     DPS_Status (*setCert)(DPS_KeyStoreRequest* request, const char* cert, size_t certLen,
                           const char* key, size_t keyLen, const char* pwd, size_t pwdLen);

--- a/inc/dps/private/network.h
+++ b/inc/dps/private/network.h
@@ -29,6 +29,7 @@
 #define _NETWORK_H
 
 #include <stdint.h>
+#include <uv.h>
 #include <dps/private/dps.h>
 
 #ifdef __cplusplus

--- a/src/coap.h
+++ b/src/coap.h
@@ -30,6 +30,7 @@
 
 #include <stdint.h>
 #include <stddef.h>
+#include <uv.h>
 #include <dps/private/dps.h>
 
 #ifdef __cplusplus

--- a/src/dps.c
+++ b/src/dps.c
@@ -1443,11 +1443,6 @@ DPS_NetContext* DPS_GetNetContext(DPS_Node* node)
     return node->netCtx;
 }
 
-uv_loop_t* DPS_GetLoop(DPS_Node* node)
-{
-    return node->loop;
-}
-
 uint16_t DPS_GetPortNumber(DPS_Node* node)
 {
     DPS_DBGTRACE();

--- a/src/dtls/network.c
+++ b/src/dtls/network.c
@@ -852,7 +852,7 @@ static DPS_NetConnection* CreateConnection(DPS_Node* node, const struct sockaddr
     cn->timerStatus = -1;
     cn->timer.data = cn;
 
-    uv_idle_init(DPS_GetLoop(node), &cn->idleForSendCallbacks);
+    uv_idle_init(node->loop, &cn->idleForSendCallbacks);
     cn->idleForSendCallbacks.data = cn;
 
     /*
@@ -861,7 +861,7 @@ static DPS_NetConnection* CreateConnection(DPS_Node* node, const struct sockaddr
      */
     if (type == MBEDTLS_SSL_IS_CLIENT) {
         struct sockaddr_storage addr;
-        ret = uv_udp_init(DPS_GetLoop(node), &cn->socket);
+        ret = uv_udp_init(node->loop, &cn->socket);
         if (ret) {
             DPS_ERRPRINT("UDP init failed: %s\n", uv_err_name(ret));
             goto ErrorExit;
@@ -1395,7 +1395,7 @@ DPS_NetContext* DPS_NetStart(DPS_Node* node, uint16_t port, DPS_OnReceive cb)
     if (!netCtx) {
         return NULL;
     }
-    ret = uv_udp_init(DPS_GetLoop(node), &netCtx->rxSocket);
+    ret = uv_udp_init(node->loop, &netCtx->rxSocket);
     if (ret) {
         DPS_ERRPRINT("UDP init failed- %s\n", uv_err_name(ret));
         free(netCtx);

--- a/src/event.c
+++ b/src/event.c
@@ -22,6 +22,7 @@
 
 #include <stdlib.h>
 #include <safe_lib.h>
+#include <uv.h>
 #include <dps/dps.h>
 #include <dps/dbg.h>
 #include <dps/event.h>

--- a/src/multicast/network.c
+++ b/src/multicast/network.c
@@ -28,6 +28,7 @@
 #include <dps/dps.h>
 #include <dps/private/network.h>
 #include "../coap.h"
+#include "../node.h"
 
 /*
  * Debug control for this module
@@ -114,7 +115,7 @@ static DPS_Status MulticastRxInit(DPS_MulticastReceiver* receiver)
 {
     int ret;
     struct sockaddr_storage recv_addr;
-    uv_loop_t* uv = DPS_GetLoop(receiver->node);
+    uv_loop_t* uv = receiver->node->loop;
     uv_interface_address_t* ifsAddrs;
     int numIfs;
     int i;
@@ -248,7 +249,7 @@ void DPS_MulticastStopReceive(DPS_MulticastReceiver* receiver)
 static DPS_Status MulticastTxInit(DPS_MulticastSender* sender)
 {
     int ret;
-    uv_loop_t* uv = DPS_GetLoop(sender->node);
+    uv_loop_t* uv = sender->node->loop;
     uv_interface_address_t* ifsAddrs;
     TxSocket* sock;
     int numIfs;

--- a/src/registration.c
+++ b/src/registration.c
@@ -213,7 +213,7 @@ static void OnLinkedPut(DPS_Node* node, DPS_NodeAddress* addr, DPS_Status ret, v
          * Start a timer
          */
         int r;
-        r = uv_timer_init(DPS_GetLoop(node), &regPut->timer);
+        r = uv_timer_init(node->loop, &regPut->timer);
         if (!r) {
             regPut->timer.data = regPut;
             r = uv_timer_start(&regPut->timer, OnPutTimeout, regPut->timeout, 0);
@@ -534,7 +534,7 @@ static void OnLinkedGet(DPS_Node* node, DPS_NodeAddress* addr, DPS_Status ret, v
              */
             if (regGet->status == DPS_OK) {
                 int r;
-                r = uv_timer_init(DPS_GetLoop(node), &regGet->timer);
+                r = uv_timer_init(node->loop, &regGet->timer);
                 if (!r) {
                     regGet->timer.data = regGet;
                     r = uv_timer_start(&regGet->timer, OnGetTimeout, regGet->timeout, 0);

--- a/src/tcp/network.c
+++ b/src/tcp/network.c
@@ -338,7 +338,7 @@ DPS_NetContext* DPS_NetStart(DPS_Node* node, uint16_t port, DPS_OnReceive cb)
     if (!netCtx) {
         return NULL;
     }
-    ret = uv_tcp_init(DPS_GetLoop(node), &netCtx->socket);
+    ret = uv_tcp_init(node->loop, &netCtx->socket);
     if (ret) {
         DPS_ERRPRINT("uv_tcp_init error=%s\n", uv_err_name(ret));
         free(netCtx);
@@ -517,7 +517,7 @@ DPS_Status DPS_NetSend(DPS_Node* node, void* appCtx, DPS_NetEndpoint* ep, uv_buf
     if (!ep->cn) {
         goto ErrExit;
     }
-    r = uv_tcp_init(DPS_GetLoop(node), &ep->cn->socket);
+    r = uv_tcp_init(node->loop, &ep->cn->socket);
     if (r) {
         goto ErrExit;
     }

--- a/src/udp/network.c
+++ b/src/udp/network.c
@@ -99,7 +99,7 @@ DPS_NetContext* DPS_NetStart(DPS_Node* node, uint16_t port, DPS_OnReceive cb)
     if (!netCtx) {
         return NULL;
     }
-    ret = uv_udp_init(DPS_GetLoop(node), &netCtx->rxSocket);
+    ret = uv_udp_init(node->loop, &netCtx->rxSocket);
     if (ret) {
         DPS_ERRPRINT("uv_tcp_init error=%s\n", uv_err_name(ret));
         free(netCtx);

--- a/swig/dps.i
+++ b/swig/dps.i
@@ -67,6 +67,7 @@
 
 %{
 #include <safe_lib.h>
+#include <uv.h>
 #include <dps/dbg.h>
 #include <dps/dps.h>
 #include <dps/err.h>

--- a/test/dtls_fuzzer.c
+++ b/test/dtls_fuzzer.c
@@ -22,6 +22,7 @@
 
 #include "test.h"
 #include "keys.h"
+#include <uv.h>
 
 #define A_SIZEOF(a)  (sizeof(a) / sizeof((a)[0]))
 

--- a/test/version.c
+++ b/test/version.c
@@ -177,7 +177,7 @@ static void NetSend(DPS_Node* node, DPS_NetEndpoint* ep, int version, int type)
         exit(EXIT_FAILURE);
     }
     async->data = data;
-    ret = uv_async_init(DPS_GetLoop(node), async, NetSendTask);
+    ret = uv_async_init(node->loop, async, NetSendTask);
     if (ret < 0) {
         DPS_ERRPRINT("uv_async_init failed: %s\n", uv_strerror(ret));
         exit(EXIT_FAILURE);


### PR DESCRIPTION
Since libuv may now be statically linked in, it is not expected that
users of the DPS libs will have the header installed.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>