### PR TITLE
Add simple SConscript for building an application

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,3 +15,12 @@ computing in combination with cloud-based analytics.
 ## [Building and Running](https://intel.github.io/dps-for-iot/building-and-running.html)
 
 ## [Documentation](https://intel.github.io/dps-for-iot)
+
+In application subdirectory there is a simple SConscript that can be used as a template for
+building your own statically linked DPS C application. Copy the application tree somewhere
+and add your source and header files to the src and include directories.
+
+To build:
+
+scons -C <dps-root-dir> application=<your-application-dir> bindings=none
+

--- a/SConscript
+++ b/SConscript
@@ -268,3 +268,7 @@ try:
 except:
     # Doxygen may not be installed
     pass
+
+# Return the static DPS library
+result = [lib]
+Return('result')

--- a/SConstruct
+++ b/SConstruct
@@ -11,6 +11,7 @@ vars.AddVariables(
     EnumVariable('transport', 'Transport protocol', default='udp', allowed_values=('udp', 'tcp', 'dtls', 'fuzzer'), ignorecase=2),
     EnumVariable('target', 'Build target', default='local', allowed_values=('local', 'yocto'), ignorecase=2),
     ListVariable('bindings', 'Bindings to build', bindings, bindings),
+    PathVariable('application', 'Application to build', '', PathVariable.PathAccept),
     ('CC', 'C compiler to use'),
     ('CXX', 'C++ compiler to use'))
 
@@ -250,7 +251,13 @@ if extUV: ext_libs.append(SConscript('ext/SConscript.libuv', exports=['extEnv'])
 
 version = '0.9.0'
 
-SConscript('SConscript', src_dir='.', variant_dir='build/obj', duplicate=0, exports=['env', 'ext_libs', 'extUV', 'version'])
+lib_dps = SConscript('SConscript', src_dir='.', variant_dir='build/obj', duplicate=0, exports=['env', 'ext_libs', 'extUV', 'version'])
+
+
+# Build any user applications
+if env['application'] != '':
+    print('Buidling application in ', env['application'])
+    SConscript(env['application'] + '/SConscript', variant_dir=env['application'] + '/build/obj', duplicate=0, exports=['env', 'ext_libs', 'lib_dps'])
 
 ######################################################################
 # Scons to generate the dps_ns3.pc file from dps_ns3.pc.in file

--- a/application/SConscript
+++ b/application/SConscript
@@ -1,0 +1,27 @@
+import os
+import string
+Import(['env', 'ext_libs', 'lib_dps'])
+
+platform = env['PLATFORM']
+
+app_env = env.Clone()
+if app_env['PLATFORM'] == 'win32':
+    app_env.Append(CPPDEFINES = ['_CRT_SECURE_NO_WARNINGS'])
+
+# Add local include directory to the include path
+app_env.Append(CPPPATH=['./include'])
+
+# Libraries will be statically linked
+app_env['LIBS'] = [lib_dps] + [ext_libs] + env['DPS_LIBS']
+
+# Source files
+app_srcs = Glob('src/*.c')
+
+# Application depends on the libraries
+Depends(app_srcs, app_env['LIBS'])
+
+# Build the executable
+app_program = app_env.Program(app_srcs)
+
+# Install the executable in the bin directory
+app_env.Install('#/' + app_env['application'] + '/bin', app_program)

--- a/application/include/my_app.h
+++ b/application/include/my_app.h
@@ -1,0 +1,38 @@
+/*
+ *******************************************************************
+ *
+ * Copyright 2018 Intel Corporation All rights reserved.
+ *
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ *-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=-=
+ */
+
+#ifndef _MY_APP_H
+#define _MY_APP_H
+
+#include <dps/dps.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+DPS_Node* node;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/application/src/my_app.c
+++ b/application/src/my_app.c
@@ -1,0 +1,23 @@
+#include <dps/dps.h>
+#include <dps/dbg.h>
+#include "my_app.h"
+
+int main(int argc, char** argv)
+{
+    DPS_Status ret;
+
+    node = DPS_CreateNode("/", NULL, 0);
+    if (!node) {
+        DPS_ERRPRINT("Could not create node - exiting\n");
+        return 1;
+    }
+    ret = DPS_StartNode(node, DPS_MCAST_PUB_ENABLE_SEND, 0);
+    if (ret != DPS_OK) {
+        DPS_ERRPRINT("DPS_StartNode failed: %s\n", DPS_ErrTxt(ret));
+        return 1;
+    } 
+    DPS_DestroyNode(node, NULL, NULL);
+    return 0;
+}
+
+


### PR DESCRIPTION
SCons can be a bit intimidating. This patch provides a simpls SConscript
that can be used to build a statically linked DPS application either
underneath the DPS source tree or elsewhere.

Signed-off-by: Greg Burns <gregory.burns@intel.com>