### PR TITLE
Simplify serialization of fuzzy-hash bit vectors

### DIFF
--- a/src/bitvec.h
+++ b/src/bitvec.h
@@ -233,6 +233,16 @@ DPS_Status DPS_BitVectorUnion(DPS_BitVector* bvOut, DPS_BitVector* bv);
 DPS_Status DPS_BitVectorSerialize(DPS_BitVector* bv, DPS_TxBuffer* buffer);
 
 /**
+ * Serialize a fuzzy-hash bit vector into a buffer
+ *
+ * @param bv      The bit vector to serialize
+ * @param buffer  The buffer to serialize the bit vector into
+ *
+ * @return  The success or failure of the operation
+ */
+DPS_Status DPS_BitVectorSerializeFH(DPS_BitVector* bv, DPS_TxBuffer* buffer);
+
+/**
  * Maximum buffer space needed to serialize a bit vector.
  *
  * @param bv  The bit vector to check
@@ -242,7 +252,14 @@ DPS_Status DPS_BitVectorSerialize(DPS_BitVector* bv, DPS_TxBuffer* buffer);
 size_t DPS_BitVectorSerializeMaxSize(DPS_BitVector* bv);
 
 /**
- * Deserialize an decompress a bit vector from a buffer
+ * Buffer space needed to serialize a fuzzy hash bit vector.
+ *
+ * @return  The space needed to serialize a fuzzy hash bit vector.
+ */
+size_t DPS_BitVectorSerializeFHSize();
+
+/**
+ * Deserialize and decompress a bit vector from a buffer
  *
  * @param bv      Allocated bit vector to deserialize into
  * @param buffer  The buffer containing a serialized bit vector
@@ -250,6 +267,16 @@ size_t DPS_BitVectorSerializeMaxSize(DPS_BitVector* bv);
  * @return  an initialized bit vector or null if the deserialization failed
  */
 DPS_Status DPS_BitVectorDeserialize(DPS_BitVector* bv, DPS_RxBuffer* buffer);
+
+/**
+ * Deserialize a fuzzy hash bit vector from a buffer
+ *
+ * @param bv      Allocated bit vector to deserialize into
+ * @param buffer  The buffer containing a serialized bit vector
+ *
+ * @return  an initialized bit vector or null if the deserialization failed
+ */
+DPS_Status DPS_BitVectorDeserializeFH(DPS_BitVector* bv, DPS_RxBuffer* buffer);
 
 /**
  * Clear all bits in an existing bit vector.

--- a/src/sub.c
+++ b/src/sub.c
@@ -234,7 +234,8 @@ DPS_Status DPS_SendSubscription(DPS_Node* node, RemoteNode* remote)
                CBOR_SIZEOF(uint8_t) +
                CBOR_SIZEOF_BYTES(sizeof(DPS_UUID)) +
                DPS_BitVectorSerializeMaxSize(interests) +
-               DPS_BitVectorSerializeMaxSize(remote->outbound.needs);
+               DPS_BitVectorSerializeFHSize();
+
     } else {
         interests = NULL;
     }
@@ -293,7 +294,7 @@ DPS_Status DPS_SendSubscription(DPS_Node* node, RemoteNode* remote)
             ret = CBOR_EncodeUint8(&buf, DPS_CBOR_KEY_NEEDS);
         }
         if (ret == DPS_OK) {
-            ret = DPS_BitVectorSerialize(remote->outbound.needs, &buf);
+            ret = DPS_BitVectorSerializeFH(remote->outbound.needs, &buf);
         }
         if (ret == DPS_OK) {
             ret = CBOR_EncodeUint8(&buf, DPS_CBOR_KEY_INTERESTS);
@@ -436,7 +437,7 @@ static DPS_Status SendSubscriptionAck(DPS_Node* node, RemoteNode* remote, uint32
             ret = CBOR_EncodeUint8(&buf, DPS_CBOR_KEY_NEEDS);
         }
         if (ret == DPS_OK) {
-            ret = DPS_BitVectorSerialize(remote->outbound.needs, &buf);
+            ret = DPS_BitVectorSerializeFH(remote->outbound.needs, &buf);
         }
         if (ret == DPS_OK) {
             ret = CBOR_EncodeUint8(&buf, DPS_CBOR_KEY_INTERESTS);
@@ -599,7 +600,7 @@ DPS_Status DPS_DecodeSubscription(DPS_Node* node, DPS_NetEndpoint* ep, DPS_RxBuf
             } else {
                 needs = DPS_BitVectorAllocFH();
                 if (needs) {
-                    ret = DPS_BitVectorDeserialize(needs, buf);
+                    ret = DPS_BitVectorDeserializeFH(needs, buf);
                 } else {
                     ret = DPS_ERR_RESOURCES;
                 }


### PR DESCRIPTION
Unlike the bloom filters the fuzzy hash bit vectors are small and will typically not be sparse so
there is little to be gained by attempting to compress them.

Note that this patch changes the wire protocol.

Signed-off-by: Greg Burns <gregory.burns@intel.com>