### PR TITLE
Replace copy of byte arrays in Python binding with pointer.

### DIFF
--- a/py_scripts/simple_pub.py
+++ b/py_scripts/simple_pub.py
@@ -106,6 +106,7 @@ parser.add_argument("-p", "--port", type=int, default=0,
 
 args = parser.parse_args()
 dps.cvar.debug = args.debug
+mcast = dps.MCAST_PUB_ENABLE_SEND
 
 key_store = dps.create_memory_key_store()
 dps.set_network_key(key_store, network_key_id, network_key)
@@ -138,9 +139,12 @@ def on_destroy(node):
     print "Destroyed"
     dps.destroy_key_store(key_store)
 
+if args.port != 0:
+    mcast = dps.MCAST_PUB_DISABLED
+
 node = dps.create_node("/", key_store, node_id)
-dps.start_node(node, dps.MCAST_PUB_ENABLE_SEND, args.listen)
 print "Publisher is listening on port %d" % (dps.get_port_number(node))
+dps.start_node(node, mcast, args.listen)
 
 if args.port != 0:
     addr = dps.create_address()

--- a/swig/js/dps_impl.i
+++ b/swig/js/dps_impl.i
@@ -58,7 +58,7 @@ static int AsVal_bytes(Handle obj, uint8_t** bytes, size_t* len)
     } else if (!obj->IsNull()) {
         return SWIG_TypeError;
     }
-    return SWIG_OK;
+    return SWIG_NEWOBJ;
 }
 
 static Handle From_bytes(const uint8_t* bytes, size_t len)

--- a/swig/py/dps_impl.i
+++ b/swig/py/dps_impl.i
@@ -22,12 +22,16 @@
 %{
 static int AsVal_bytes(Handle obj, uint8_t** bytes, size_t* len)
 {
-    int alloc = SWIG_NEWOBJ;
+    int alloc = SWIG_OLDOBJ;
     if (SWIG_IsOK(SWIG_AsCharPtrAndSize(obj, (char**)bytes, len, &alloc))) {
         if (*len) {
             --(*len);
         }
-        return SWIG_OK;
+        return alloc;
+    } else if (PyByteArray_Check(obj)) {
+        *len = PyByteArray_GET_SIZE(obj);
+        *bytes = (uint8_t*)PyByteArray_AS_STRING(obj);
+        return SWIG_OLDOBJ;
     } else if (PySequence_Check(obj)) {
         Py_ssize_t sz = PySequence_Length(obj);
         Py_ssize_t i;
@@ -47,7 +51,7 @@ static int AsVal_bytes(Handle obj, uint8_t** bytes, size_t* len)
             }
             *len = sz;
         }
-        return SWIG_OK;
+        return SWIG_NEWOBJ;
     } else {
         return SWIG_TypeError;
     }


### PR DESCRIPTION
This makes the performance of the Python publish() comparable to the
native C DPS_Publish().

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>