### PR TITLE
Add min-size-release variant.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -15,7 +15,7 @@ vars.AddVariables(
     BoolVariable('ubsan', 'Enable undefined behavior sanitizer?', False),
     BoolVariable('fsan', 'Enable fuzzer sanitizer?', False),
     BoolVariable('cov', 'Enable code coverage?', False),
-    EnumVariable('variant', 'Build variant', default='release', allowed_values=('debug', 'release'), ignorecase=2),
+    EnumVariable('variant', 'Build variant', default='release', allowed_values=('debug', 'release', 'min-size-release'), ignorecase=2),
     EnumVariable('transport', 'Transport protocol', default='udp', allowed_values=('udp', 'tcp', 'dtls', 'pipe', 'fuzzer'), ignorecase=2),
     EnumVariable('target', 'Build target', default='local', allowed_values=('local', 'yocto'), ignorecase=2),
     ListVariable('bindings', 'Bindings to build', bindings, bindings),
@@ -136,7 +136,7 @@ if env['CC'] == 'cl':
     if env['variant'] == 'debug':
         env.Append(CCFLAGS = ['/Zi', '/MT', '/Od', '-DDPS_DEBUG'])
         env.Append(LINKFLAGS = ['/DEBUG'])
-    else:
+    else: # release, min-size-release
         env.Append(CCFLAGS = ['/Gy', '/O2', '/GF', '/GL', '/MT'])
         env.Append(ARFLAGS = ['/LTCG'])
         env.Append(LINKFLAGS = ['/opt:ref', '/LTCG'])
@@ -225,8 +225,11 @@ else:
 
     if env['variant'] == 'debug':
         env.Append(CCFLAGS = ['-O', '-DDPS_DEBUG'])
-    else:
+    elif env['variant'] == 'release':
         env.Append(CCFLAGS = ['-O3', '-DNDEBUG'])
+    else: # min-size-release
+        env.Append(CCFLAGS = ['-Os', '-DNDEBUG', '-fdata-sections', '-ffunction-sections'])
+        env.Append(LINKFLAGS = ['-Wl,--gc-sections', '-Wl,--strip-all'])
 
 if env['PLATFORM'] == 'win32' and 'gcc' in env['CC']:
     env.Append(CPPDEFINES = ['__USE_MINGW_ANSI_STDIO=1'])

--- a/src/history.c
+++ b/src/history.c
@@ -86,7 +86,7 @@ static DPS_PubHistory* Insert(DPS_History* history, DPS_PubHistory* add)
 {
     DPS_PubHistory* curr = history->root;
     DPS_PubHistory* parent = NULL;
-    int cmp;
+    int cmp = 0;
 
     while (curr) {
         cmp = DPS_UUIDCompare(&add->id, &curr->id);

--- a/test/make_mesh.c
+++ b/test/make_mesh.c
@@ -323,7 +323,7 @@ static int ReadLinks(const char* fn)
     }
     while (1) {
         int ep1;
-        int ep2;
+        int ep2 = 0;
         ssize_t len;
         char line[32];
 

--- a/test/mesh_stress.c
+++ b/test/mesh_stress.c
@@ -182,7 +182,7 @@ static int ReadLinks(const char* fn)
     }
     while (1) {
         int ep1;
-        int ep2;
+        int ep2 = 0;
         ssize_t len;
         char line[32];
 


### PR DESCRIPTION
Note: this only affects the gcc and clang builds.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>