### PR TITLE
Fix race in link test.

### DIFF
--- a/test/link.c
+++ b/test/link.c
@@ -443,11 +443,18 @@ static void TestShutdownShutdownAlready(void)
 {
     DPS_MemoryKeyStore* keyStore = NULL;
     DPS_Node* a = NULL;
+    DPS_Node* b = NULL;
+    DPS_NodeAddress* addr = NULL;
     DPS_Event* event = NULL;
     DPS_Status ret;
 
     keyStore = CreateKeyStore();
     a = CreateNode(keyStore);
+    b = CreateNode(keyStore);
+
+    addr = DPS_CreateAddress();
+    ret = DPS_LinkTo(a, DPS_GetListenAddressString(b), addr);
+    ASSERT(ret == DPS_OK);
 
     event = DPS_CreateEvent();
     ASSERT(event);
@@ -469,6 +476,8 @@ static void TestShutdownShutdownAlready(void)
     ASSERT(ret == DPS_OK);
 
     DPS_DestroyEvent(event);
+    DPS_DestroyAddress(addr);
+    DestroyNode(b);
     DestroyNode(a);
     DestroyKeyStore(keyStore);
 }


### PR DESCRIPTION
Create a connection in the shutdown error test, otherwise it's
possible for the shutdown callback to be issued before the test calls
shutdown again.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>