### PR TITLE
Fix order in discovery match test.

### DIFF
--- a/src/discovery.c
+++ b/src/discovery.c
@@ -277,7 +277,7 @@ static DPS_Status DecodeDiscoveryPayload(DPS_DiscoveryService* service, uint8_t 
     *match = DPS_FALSE;
     DPS_LockNode(node);
     for (pub = node->publications; pub && !(*match); pub = pub->next) {
-        *match = DPS_BitVectorIncludes(interests, pub->bf);
+        *match = DPS_BitVectorIncludes(pub->bf, interests);
     }
     DPS_UnlockNode(node);
 

--- a/test/keys.c
+++ b/test/keys.c
@@ -22,6 +22,8 @@
 
 #include <safe_lib.h>
 #include "keys.h"
+#include <ctype.h>
+#include <string.h>
 
 static const DPS_UUID _NetworkKeyId = {
     0x4c,0xfc,0x6b,0x75,0x0f,0x80,0x95,0xb3,0x6c,0xb7,0xc1,0x2f,0x65,0x2d,0x38,0x26
@@ -272,3 +274,29 @@ const Id AltId = {
     "-----END EC PRIVATE KEY-----\r\n",
     "DPS Node"
 };
+
+const char* KeyIdToString(const DPS_KeyId* keyId)
+{
+    static char str[128];
+    int isStr;
+    size_t i;
+
+    if (!keyId) {
+        str[0] = 0;
+    } else {
+        isStr = DPS_TRUE;
+        for (i = 0; isStr && (i < keyId->len); ++i) {
+            isStr = isprint(keyId->id[i]);
+        }
+        if (isStr) {
+            memcpy(str, keyId->id, keyId->len);
+            str[keyId->len] = 0;
+        } else {
+            char* dst = str;
+            for (i = 0; i < keyId->len; ++i) {
+                snprintf(dst, &str[sizeof(str)] - dst, "%s%02x", i ? "," : "", keyId->id[i]);
+            }
+        }
+    }
+    return str;
+}

--- a/test/keys.h
+++ b/test/keys.h
@@ -55,6 +55,8 @@ extern const Id Ids[];
 extern const char AltCA[];
 extern const Id AltId;
 
+const char* KeyIdToString(const DPS_KeyId* keyId);
+
 #ifdef __cplusplus
 }
 #endif

--- a/test_scripts/run.py
+++ b/test_scripts/run.py
@@ -34,6 +34,7 @@ if 'FSAN' not in os.environ or os.environ['FSAN'] == 'no':
              os.path.join('test_scripts', 'loop3.py'),
              os.path.join('test_scripts', 'pub100.py'),
              os.path.join('test_scripts', 'reg1.py'),
+             os.path.join('test_scripts', 'simple_discover.py'),
              os.path.join('test_scripts', 'simple_test.py'),
              os.path.join('test_scripts', 'topic_match.py'),
              os.path.join('test_scripts', 'tree0.py'),

--- a/test_scripts/simple_discover.py
+++ b/test_scripts/simple_discover.py
@@ -1,0 +1,22 @@
+#!/usr/bin/python
+
+from common import *
+import atexit
+
+atexit.register(cleanup)
+
+# No wildcard matching
+sub1 = discover('-s 1/1/1 -s 1/1/2')
+
+discover('-w -p 1/1/1 -p 1/1/2')
+
+expect_pub_received([sub1], '1/1/1')
+expect_pub_received([sub1], '1/1/2')
+
+# Wildcard matching
+sub1 = discover('-s 1/1/#')
+
+discover('-p 1/1/1 -p 1/1/2')
+
+expect_pub_received([sub1], '1/1/1')
+expect_pub_received([sub1], '1/1/2')


### PR DESCRIPTION
Prior to this fix, the match test checked if the subscription topics
included the publication topics.  This failed noticeably when the
publication included the wildcarded topics.

With this fix, the correct check is performed (publication includes
subscription) and the discovery code creates the link.

Signed-off-by: Todd Malsbary <todd.malsbary@intel.com>